### PR TITLE
Use correct module for Mojolicious prereq

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,6 @@ location = root
 [PodWeaver]
 [Prereqs]
 Moo = 1.000006
-Mojo = 3.62
+Mojolicious = 3.62
 Hash::Merge::Simple = 0.051
 perl = 5.014


### PR DESCRIPTION
Mojolicious only declares a version in its main module, not in any of the others.  If the prerequisite is declared on Mojo, the prerequisite will never be met because it doesn't have a version.
